### PR TITLE
Allow to skip product url localization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-  - 7.1
+  - 7.2
 
 env:
   COMPOSER_MEMORY_LIMIT=-1

--- a/src/FondOfSpryker/Shared/Product/ProductConstants.php
+++ b/src/FondOfSpryker/Shared/Product/ProductConstants.php
@@ -4,5 +4,7 @@ namespace FondOfSpryker\Shared\Product;
 
 interface ProductConstants
 {
-    public const URL_ATTRIBUTE_CODE = 'URL_ATTRIBUTE_CODE';
+    public const URL_ATTRIBUTE_CODE = 'PRODUCT:URL_ATTRIBUTE_CODE';
+
+    public const URL_LOCALIZATION_BLACKLIST = 'PRODUCT:URL_LOCALIZATION_BLACKLIST';
 }

--- a/src/FondOfSpryker/Shared/Product/ProductConstants.php
+++ b/src/FondOfSpryker/Shared/Product/ProductConstants.php
@@ -6,5 +6,5 @@ interface ProductConstants
 {
     public const URL_ATTRIBUTE_CODE = 'PRODUCT:URL_ATTRIBUTE_CODE';
 
-    public const URL_LOCALIZATION_BLACKLIST = 'PRODUCT:URL_LOCALIZATION_BLACKLIST';
+    public const URL_LOCALE_TO_SKIP = 'PRODUCT:URL_LOCALE_TO_SKIP';
 }

--- a/src/FondOfSpryker/Zed/Product/Business/ProductUrlGenerator.php
+++ b/src/FondOfSpryker/Zed/Product/Business/ProductUrlGenerator.php
@@ -50,11 +50,11 @@ class ProductUrlGenerator extends SprykerProductUrlGenerator
         ProductAbstractTransfer $productAbstractTransfer,
         LocaleTransfer $localeTransfer
     ): string {
-        $localizationBlacklist = $this->config->getUrlLocalizationBlacklist();
+        $urlLocaleToSkip = $this->config->getUrlLocaleToSkip();
         $urlPrefix = $this->getUrlPrefixByLocale($localeTransfer);
         $urlKey = $this->getUrlKey($productAbstractTransfer, $localeTransfer);
 
-        if ($localizationBlacklist !== null && in_array($urlPrefix, $localizationBlacklist)) {
+        if ($urlLocaleToSkip !== null && $urlPrefix === $urlLocaleToSkip) {
             return sprintf('/%s', $urlKey);
         }
 

--- a/src/FondOfSpryker/Zed/Product/Business/ProductUrlGenerator.php
+++ b/src/FondOfSpryker/Zed/Product/Business/ProductUrlGenerator.php
@@ -2,6 +2,7 @@
 
 namespace FondOfSpryker\Zed\Product\Business;
 
+use FondOfSpryker\Zed\Product\Dependency\Facade\ProductToStoreInterface;
 use FondOfSpryker\Zed\Product\ProductConfig;
 use Generated\Shared\Transfer\LocaleTransfer;
 use Generated\Shared\Transfer\ProductAbstractTransfer;
@@ -49,8 +50,13 @@ class ProductUrlGenerator extends SprykerProductUrlGenerator
         ProductAbstractTransfer $productAbstractTransfer,
         LocaleTransfer $localeTransfer
     ): string {
+        $localizationBlacklist = $this->config->getUrlLocalizationBlacklist();
         $urlPrefix = $this->getUrlPrefixByLocale($localeTransfer);
         $urlKey = $this->getUrlKey($productAbstractTransfer, $localeTransfer);
+
+        if ($localizationBlacklist !== null && in_array($urlPrefix, $localizationBlacklist)) {
+            return sprintf('/%s', $urlKey);
+        }
 
         return sprintf('/%s/%s', $urlPrefix, $urlKey);
     }

--- a/src/FondOfSpryker/Zed/Product/ProductConfig.php
+++ b/src/FondOfSpryker/Zed/Product/ProductConfig.php
@@ -16,10 +16,10 @@ class ProductConfig extends AbstractBundleConfig
     }
 
     /**
-     * @return array|null
+     * @return string|null
      */
-    public function getUrlLocalizationBlacklist(): ?array
+    public function getUrlLocaleToSkip(): ?string
     {
-        return $this->get(ProductConstants::URL_LOCALIZATION_BLACKLIST);
+        return $this->get(ProductConstants::URL_LOCALE_TO_SKIP);
     }
 }

--- a/src/FondOfSpryker/Zed/Product/ProductConfig.php
+++ b/src/FondOfSpryker/Zed/Product/ProductConfig.php
@@ -14,4 +14,12 @@ class ProductConfig extends AbstractBundleConfig
     {
         return $this->get(ProductConstants::URL_ATTRIBUTE_CODE);
     }
+
+    /**
+     * @return array|null
+     */
+    public function getUrlLocalizationBlacklist(): ?array
+    {
+        return $this->get(ProductConstants::URL_LOCALIZATION_BLACKLIST);
+    }
 }

--- a/src/FondOfSpryker/Zed/Product/ProductDependencyProvider.php
+++ b/src/FondOfSpryker/Zed/Product/ProductDependencyProvider.php
@@ -2,13 +2,15 @@
 
 namespace FondOfSpryker\Zed\Product;
 
+use FondOfSpryker\Zed\Product\Dependency\Facade\ProductToStoreBridge;
 use FondOfSpryker\Zed\Product\Dependency\Facade\ProductToUrlBridge;
 use Spryker\Zed\Kernel\Container;
 use Spryker\Zed\Product\ProductDependencyProvider as BaseProductDependencyProvider;
 
 class ProductDependencyProvider extends BaseProductDependencyProvider
 {
-    public const FACADE_URL = 'FACADE_URL';
+    public const FACADE_URL = 'PRODUCT:FACADE_URL';
+    public const FACADE_STORE = 'PRODUCT:FACADE_STORE';
 
     /**
      * @param \Spryker\Zed\Kernel\Container $container
@@ -19,6 +21,7 @@ class ProductDependencyProvider extends BaseProductDependencyProvider
     {
         $container = parent::provideBusinessLayerDependencies($container);
         $container = $this->addUrlFacade($container);
+        $container = $this->addStoreFacade($container);
 
         return $container;
     }
@@ -32,6 +35,20 @@ class ProductDependencyProvider extends BaseProductDependencyProvider
     {
         $container[static::FACADE_URL] = function (Container $container) {
             return new ProductToUrlBridge($container->getLocator()->url()->facade());
+        };
+
+        return $container;
+    }
+
+    /**
+     * @param \Spryker\Zed\Kernel\Container $container
+     *
+     * @return \Spryker\Zed\Kernel\Container
+     */
+    protected function addStoreFacade(Container $container): Container
+    {
+        $container[static::FACADE_STORE] = function (Container $container) {
+            return new ProductToStoreBridge($container->getLocator()->store()->facade());
         };
 
         return $container;

--- a/tests/FondOfSpryker/Zed/Product/Business/ProductUrlGeneratorTest.php
+++ b/tests/FondOfSpryker/Zed/Product/Business/ProductUrlGeneratorTest.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace FondOfSpryker\Zed\Product\Business;
+
+use Codeception\Test\Unit;
+use FondOfSpryker\Zed\Product\ProductConfig;
+use Generated\Shared\Transfer\LocaleTransfer;
+use Generated\Shared\Transfer\ProductAbstractTransfer;
+use ReflectionClass;
+use Spryker\Zed\Product\Business\Product\NameGenerator\ProductAbstractNameGenerator;
+use Spryker\Zed\Product\Business\Product\NameGenerator\ProductAbstractNameGeneratorInterface;
+use Spryker\Zed\Product\Dependency\Facade\ProductToLocaleBridge;
+use Spryker\Zed\Product\Dependency\Facade\ProductToLocaleInterface;
+use Spryker\Zed\Product\Dependency\Service\ProductToUtilTextBridge;
+use Spryker\Zed\Product\Dependency\Service\ProductToUtilTextInterface;
+use stdClass;
+
+class ProductUrlGeneratorTest extends Unit
+{
+    /**
+     * @var \ReflectionClass
+     */
+    private $productUrlGenerator;
+
+    /**
+     * @var \Generated\Shared\Transfer\LocaleTransfer
+     */
+    private $localeTransferMock;
+
+    /**
+     * @var \Generated\Shared\Transfer\ProductAbstractTransfer
+     */
+    private $productAbstractTransfer;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject
+     */
+    private $configMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject
+     */
+    private $productUrlGeneratorMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject
+     */
+    private $productAbtractNameGeneratorMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject
+     */
+    private $utilTextBridgeMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject
+     */
+    private $localeBridgeMock;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        $this->configMock = $this->getMockBuilder(ProductConfig::class)
+            ->onlyMethods(['getUrlLocaleToSkip', 'getUrlAttributeCode'])
+            ->getMock();
+        $this->configMock->method('getUrlAttributeCode')->willReturn('url_key');
+
+        $this->productAbtractNameGeneratorMock = $this->getMockBuilder(ProductAbstractNameGenerator::class)
+            ->onlyMethods(['getLocalizedProductAbstractName'])
+            ->getMock();
+
+        $this->productAbtractNameGeneratorMock->method('getLocalizedProductAbstractName')
+            ->willReturn('ergobag cubo');
+
+        $this->utilTextBridgeMock = $this->getMockBuilder(ProductToUtilTextBridge::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['generateSlug'])
+            ->getMock();
+
+        $this->utilTextBridgeMock->method('generateSlug')->willReturn('ergobag-cubo');
+
+        $this->localeBridgeMock = $this->getMockBuilder(ProductToLocaleBridge::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->localeTransferMock = new LocaleTransfer();
+        $this->productAbstractTransfer = new ProductAbstractTransfer();
+        $this->productAbstractTransfer->setIdProductAbstract('1');
+    }
+
+    /**
+     * @return void
+     */
+    public function testGenerateUrlByLocale(): void
+    {
+        $mockUrlGenerator = $this->getProductUrlGeneratorMock('de');
+        $productUrlGenerator = new ReflectionClass(ProductUrlGenerator::class);
+        $generateUrlByLocale = $productUrlGenerator->getMethod('generateUrlByLocale');
+        $generateUrlByLocale->setAccessible(true);
+
+        $url = $generateUrlByLocale->invoke(
+            $mockUrlGenerator,
+            $this->productAbstractTransfer,
+            $this->localeTransferMock
+        );
+
+        $this->assertEquals('/de/ergobag-cubo-1', $url);
+    }
+
+    /**
+     * @return void
+     */
+    public function testGenerateUrlSkipLocale(): void
+    {
+        $this->configMock->method('getUrlLocaleToSkip')->willReturn('de');
+
+        $mockUrlGenerator = $this->getProductUrlGeneratorMock('de');
+        $productUrlGenerator = new ReflectionClass(ProductUrlGenerator::class);
+        $generateUrlByLocale = $productUrlGenerator->getMethod('generateUrlByLocale');
+        $generateUrlByLocale->setAccessible(true);
+
+        $url = $generateUrlByLocale->invoke(
+            $mockUrlGenerator,
+            $this->productAbstractTransfer,
+            $this->localeTransferMock
+        );
+
+        $this->assertEquals('/ergobag-cubo-1', $url);
+    }
+
+    /**
+     * @return void
+     */
+    public function testGenerateUrlDontSkipLocale(): void
+    {
+        $this->configMock->method('getUrlLocaleToSkip')->willReturn('de');
+
+        $mockUrlGenerator = $this->getProductUrlGeneratorMock('en');
+        $productUrlGenerator = new ReflectionClass(ProductUrlGenerator::class);
+        $generateUrlByLocale = $productUrlGenerator->getMethod('generateUrlByLocale');
+        $generateUrlByLocale->setAccessible(true);
+
+        $url = $generateUrlByLocale->invoke(
+            $mockUrlGenerator,
+            $this->productAbstractTransfer,
+            $this->localeTransferMock
+        );
+
+        $this->assertEquals('/en/ergobag-cubo-1', $url);
+    }
+
+    /**
+     * @param string $locale
+     * @return \FondOfSpryker\Zed\Product\Business\ProductUrlGenerator
+     */
+    private function getProductUrlGeneratorMock(string $locale): ProductUrlGenerator
+    {
+        return new class(
+            $this->productAbtractNameGeneratorMock,
+            $this->localeBridgeMock,
+            $this->utilTextBridgeMock,
+            $this->configMock,
+            $locale
+        ) extends ProductUrlGenerator {
+            public $mockLocale;
+            public function __construct(
+                ProductAbstractNameGeneratorInterface $productAbstractNameGenerator,
+                ProductToLocaleInterface $localeFacade,
+                ProductToUtilTextInterface $utilTextService,
+                ProductConfig $config,
+                $locale
+            )
+            {
+                $this->mockLocale = $locale;
+                parent::__construct(
+                    $productAbstractNameGenerator,
+                    $localeFacade,
+                    $utilTextService,
+                    $config
+                );
+            }
+
+            protected function getUrlPrefixByLocale(LocaleTransfer $localeTransfer): string {
+                return $this->mockLocale;
+            }
+        };
+    }
+}

--- a/tests/FondOfSpryker/Zed/Product/ProductConfigTest.php
+++ b/tests/FondOfSpryker/Zed/Product/ProductConfigTest.php
@@ -3,37 +3,39 @@
 namespace FondOfSpryker\Zed\Product;
 
 use Codeception\Test\Unit;
-use org\bovigo\vfs\vfsStream;
 
 class ProductConfigTest extends Unit
 {
     /**
-     * @var \org\bovigo\vfs\vfsStreamDirectory
+     * @var \PHPUnit\Framework\MockObject\MockObject
      */
-    protected $vfsStreamDirectory;
+    private $configMock;
 
     /**
      * @return void
      */
-    public function _before()
+    public function _before(): void
     {
-        $this->vfsStreamDirectory = vfsStream::setup('root', null, [
-            'config' => [
-                'Shared' => [
-                    'stores.php' => file_get_contents(codecept_data_dir('stores.php')),
-                    'config_default.php' => file_get_contents(codecept_data_dir('config_default.php')),
-                ],
-            ],
-        ]);
+        $this->configMock = $this->getMockBuilder(ProductConfig::class)
+            ->onlyMethods(['getUrlAttributeCode', 'getUrlLocaleToSkip'])
+            ->getMock();
     }
 
     /**
      * @return void
      */
-    public function testGetUrlAttributeCode()
+    public function testGetUrlAttributeCode(): void
     {
-        $productConfig = new ProductConfig();
+        $this->configMock->method('getUrlAttributeCode')->willReturn('url_key');
+        $this->assertEquals('url_key', $this->configMock->getUrlAttributeCode());
+    }
 
-        $this->assertEquals('url_key', $productConfig->getUrlAttributeCode());
+    /**
+     * @return void
+     */
+    public function testGetUrlLocaleToSkip(): void
+    {
+        $this->configMock->method('getUrlLocaleToSkip')->willReturn('de');
+        $this->assertEquals('de', $this->configMock->getUrlLocaleToSkip());
     }
 }


### PR DESCRIPTION
This is a solution to remove the url prefix for locales in product urls. It will help to support a different url in front of the store.

Example:

foobar.com/de -> foobar.de/
foobar.com/de/fizzbazz -> foobar.de/fizzbazz