### PR TITLE
Set default value to empty string

### DIFF
--- a/src/FondOfSpryker/Zed/Product/Business/ProductUrlGenerator.php
+++ b/src/FondOfSpryker/Zed/Product/Business/ProductUrlGenerator.php
@@ -54,7 +54,7 @@ class ProductUrlGenerator extends SprykerProductUrlGenerator
         $urlPrefix = $this->getUrlPrefixByLocale($localeTransfer);
         $urlKey = $this->getUrlKey($productAbstractTransfer, $localeTransfer);
 
-        if ($urlLocaleToSkip !== null && $urlPrefix === $urlLocaleToSkip) {
+        if ($urlLocaleToSkip !== '' && $urlPrefix === $urlLocaleToSkip) {
             return sprintf('/%s', $urlKey);
         }
 
@@ -77,7 +77,7 @@ class ProductUrlGenerator extends SprykerProductUrlGenerator
 
         $urlKey = $slug . '-' . $productAbstractTransfer->getIdProductAbstract();
 
-        if ($urlAttributeCode === null) {
+        if ($urlAttributeCode === '') {
             return $urlKey;
         }
 

--- a/src/FondOfSpryker/Zed/Product/ProductConfig.php
+++ b/src/FondOfSpryker/Zed/Product/ProductConfig.php
@@ -12,7 +12,7 @@ class ProductConfig extends AbstractBundleConfig
      */
     public function getUrlAttributeCode(): ?string
     {
-        return $this->get(ProductConstants::URL_ATTRIBUTE_CODE);
+        return $this->get(ProductConstants::URL_ATTRIBUTE_CODE, null);
     }
 
     /**
@@ -20,6 +20,6 @@ class ProductConfig extends AbstractBundleConfig
      */
     public function getUrlLocaleToSkip(): ?string
     {
-        return $this->get(ProductConstants::URL_LOCALE_TO_SKIP);
+        return $this->get(ProductConstants::URL_LOCALE_TO_SKIP, null);
     }
 }

--- a/src/FondOfSpryker/Zed/Product/ProductConfig.php
+++ b/src/FondOfSpryker/Zed/Product/ProductConfig.php
@@ -8,17 +8,17 @@ use Spryker\Zed\Kernel\AbstractBundleConfig;
 class ProductConfig extends AbstractBundleConfig
 {
     /**
-     * @return string|null
+     * @return string
      */
-    public function getUrlAttributeCode(): ?string
+    public function getUrlAttributeCode(): string
     {
         return $this->get(ProductConstants::URL_ATTRIBUTE_CODE, '');
     }
 
     /**
-     * @return string|null
+     * @return string
      */
-    public function getUrlLocaleToSkip(): ?string
+    public function getUrlLocaleToSkip(): string
     {
         return $this->get(ProductConstants::URL_LOCALE_TO_SKIP, '');
     }

--- a/src/FondOfSpryker/Zed/Product/ProductConfig.php
+++ b/src/FondOfSpryker/Zed/Product/ProductConfig.php
@@ -12,7 +12,7 @@ class ProductConfig extends AbstractBundleConfig
      */
     public function getUrlAttributeCode(): ?string
     {
-        return $this->get(ProductConstants::URL_ATTRIBUTE_CODE, null);
+        return $this->get(ProductConstants::URL_ATTRIBUTE_CODE, '');
     }
 
     /**
@@ -20,6 +20,6 @@ class ProductConfig extends AbstractBundleConfig
      */
     public function getUrlLocaleToSkip(): ?string
     {
-        return $this->get(ProductConstants::URL_LOCALE_TO_SKIP, null);
+        return $this->get(ProductConstants::URL_LOCALE_TO_SKIP, '');
     }
 }


### PR DESCRIPTION
It is not allowed to use `null` as default value for a config entry. Therefor we will use an empty string. 