### PR TITLE
Allow empty value for config key "URL_ATTRIBUTE_CODE" 🎛

### DIFF
--- a/codeception.yml
+++ b/codeception.yml
@@ -1,4 +1,5 @@
-namespace: FondOfSpryker
+namespace: fond-of-spryker/product
+
 suites:
   unit:
     path: .
@@ -6,7 +7,8 @@ suites:
 settings:
   shuffle: true
   lint: true
-  bootstrap: _bootstrap.php
+
+bootstrap: _bootstrap.php
 
 paths:
   tests: tests
@@ -16,8 +18,6 @@ paths:
 
 coverage:
   enabled: true
-  include:
-    - src/*.php
 
 modules:
   enabled:

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
   "autoload-dev": {
     "psr-4": {
       "FondOfSpryker\\": "tests/FondOfSpryker/",
-      "Generated\\": "tests/Generated/"
+      "Generated\\": "src/Generated/"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,16 +21,13 @@
     }
   ],
   "require": {
-    "php": ">=7.1",
+    "php": ">=7.2",
     "spryker/product": "^6.0.0"
   },
   "require-dev": {
-    "spryker/code-sniffer": "^0.11",
-    "spryker/development": "^3.6",
-    "codeception/codeception": "^2.3",
-    "mikey179/vfsstream": "^1.6",
-    "sebastian/phpcpd": "^4.0",
-    "fond-of-codeception/spryker": "^1.0"
+    "fond-of-codeception/spryker": "^1.0",
+    "spryker/code-sniffer": "*",
+    "spryker-sdk/phpstan-spryker": "*"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -1,4 +1,0 @@
-parameters:
-    git_dir: .
-    bin_dir: vendor/bin
-    tasks: null

--- a/src/FondOfSpryker/Zed/Product/Business/ProductUrlGenerator.php
+++ b/src/FondOfSpryker/Zed/Product/Business/ProductUrlGenerator.php
@@ -32,7 +32,6 @@ class ProductUrlGenerator extends SprykerProductUrlGenerator
         ProductToUtilTextInterface $utilTextService,
         ProductConfig $config
     ) {
-
         parent::__construct($productAbstractNameGenerator, $localeFacade, $utilTextService);
 
         $this->config = $config;

--- a/src/FondOfSpryker/Zed/Product/ProductConfig.php
+++ b/src/FondOfSpryker/Zed/Product/ProductConfig.php
@@ -12,6 +12,12 @@ class ProductConfig extends AbstractBundleConfig
      */
     public function getUrlAttributeCode(): ?string
     {
-        return $this->get(ProductConstants::URL_ATTRIBUTE_CODE);
+        $urlAttributeCode = $this->get(ProductConstants::URL_ATTRIBUTE_CODE, '');
+
+        if ($urlAttributeCode === '') {
+            return null;
+        }
+
+        return $urlAttributeCode;
     }
 }

--- a/src/FondOfSpryker/Zed/Product/ProductDependencyProvider.php
+++ b/src/FondOfSpryker/Zed/Product/ProductDependencyProvider.php
@@ -30,7 +30,7 @@ class ProductDependencyProvider extends BaseProductDependencyProvider
      */
     protected function addUrlFacade(Container $container): Container
     {
-        $container[self::FACADE_URL] = function (Container $container) {
+        $container[self::FACADE_URL] = static function (Container $container) {
             return new ProductToUrlBridge($container->getLocator()->url()->facade());
         };
 

--- a/tests/FondOfSpryker/Zed/Product/ProductConfigTest.php
+++ b/tests/FondOfSpryker/Zed/Product/ProductConfigTest.php
@@ -3,28 +3,23 @@
 namespace FondOfSpryker\Zed\Product;
 
 use Codeception\Test\Unit;
-use org\bovigo\vfs\vfsStream;
+use FondOfSpryker\Shared\Product\ProductConstants;
 
 class ProductConfigTest extends Unit
 {
     /**
-     * @var \org\bovigo\vfs\vfsStreamDirectory
+     * @var \FondOfSpryker\Zed\Product\ProductConfig|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected $vfsStreamDirectory;
+    protected $productConfig;
 
     /**
      * @return void
      */
-    public function _before()
+    protected function _before(): void
     {
-        $this->vfsStreamDirectory = vfsStream::setup('root', null, [
-            'config' => [
-                'Shared' => [
-                    'stores.php' => file_get_contents(codecept_data_dir('stores.php')),
-                    'config_default.php' => file_get_contents(codecept_data_dir('config_default.php')),
-                ],
-            ],
-        ]);
+        $this->productConfig = $this->getMockBuilder(ProductConfig::class)
+            ->onlyMethods(['get'])
+            ->getMock();
     }
 
     /**
@@ -32,8 +27,24 @@ class ProductConfigTest extends Unit
      */
     public function testGetUrlAttributeCode()
     {
-        $productConfig = new ProductConfig();
+        $this->productConfig->expects(static::atLeastOnce())
+            ->method('get')
+            ->with(ProductConstants::URL_ATTRIBUTE_CODE, '')
+            ->willReturn('url_key');
 
-        $this->assertEquals('url_key', $productConfig->getUrlAttributeCode());
+        static::assertEquals('url_key', $this->productConfig->getUrlAttributeCode());
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetDefaultUrlAttributeCode()
+    {
+        $this->productConfig->expects(static::atLeastOnce())
+            ->method('get')
+            ->with(ProductConstants::URL_ATTRIBUTE_CODE, '')
+            ->willReturn('');
+
+        static::assertEquals(null, $this->productConfig->getUrlAttributeCode());
     }
 }

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -1,8 +1,5 @@
 <?php
 
-use org\bovigo\vfs\vfsStream;
-use Spryker\Shared\Config\Environment;
-
 $pathToAutoloader = codecept_root_dir('vendor/autoload.php');
 
 if (!file_exists($pathToAutoloader)) {
@@ -10,15 +7,3 @@ if (!file_exists($pathToAutoloader)) {
 }
 
 require_once $pathToAutoloader;
-
-if (!defined('APPLICATION_ENV')) {
-    define('APPLICATION_ENV', Environment::TESTING);
-}
-if (!defined('APPLICATION_STORE')) {
-    define('APPLICATION_STORE', 'UNIT');
-}
-
-if (!defined('APPLICATION_ROOT_DIR')) {
-    $stream = vfsStream::setup('root');
-    define('APPLICATION_ROOT_DIR', $stream->url());
-}

--- a/tests/_output/.gitignore
+++ b/tests/_output/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
- Use spryker functionality for generating product urls if config method "getUrlAttributeCode" returns null
- Use own logic for generating product urls if config method "getUrlAttributeCode" returns a valid string value
- Add phpstan fixes
- ...